### PR TITLE
Add multiplexer to boot pin

### DIFF
--- a/elec/src/micro.ato
+++ b/elec/src/micro.ato
@@ -37,12 +37,16 @@ module Micro:
     button ~ mux.input_b1
     can_tranciever.can_ttl.rx ~ mux.input_b2
     button ~ micro.PA4 # for enumeration or something while micro is running
-    micro.PB8_BOOT0 ~ mux.output
+    mux.output ~ micro.PB8_BOOT0
     mux.control ~ micro.PA6
 
     # Pulldown reistor to default to boot selction - assert high with PA6 to enable CAN
     select_resistor.1 ~ mux.control.io
     select_resistor.2 ~ power.gnd
+
+    # configure resistor
+    select_resistor.value = 80kohm to 120kohm # something big
+    select_resistor.package = "0402"
 
     # Motor controlxx
     phase_a_control ~ micro.PA0
@@ -55,7 +59,6 @@ module Micro:
 
     # Peripherals
     led ~ micro.PC6
-    button ~ micro.PB8_BOOT0
 
     # Internal connections
     power ~ micro.power

--- a/elec/src/micro.ato
+++ b/elec/src/micro.ato
@@ -24,15 +24,27 @@ module Micro:
     # Components
     micro = new STM32G431CBU6_USB2
     can_tranciever = new SN65HVD230DR
+    mux = new SN74LVC1G3157DBVR
+    select_resistor = new Resistor
 
     # Interfaces
     i2c ~ micro.i2c1 # (PB7 SDA, PA15 SCL)
     usb2 ~ micro.usb2 # (PA11 DM, PA12 DP)
     spi ~ micro.spi2 # (PB15 mosi, PB14 miso, PB13 sck, PB12 cs)
-    can_tranciever.can_ttl ~ micro.can_ttl # (PA12 tx, PA11 rx)
     can ~ can_tranciever.can
 
-    # Motor control
+    # CAN RX and Bootpin are shared, need to be multiplexed externally (backup for SW boot option)
+    button ~ mux.input_b1
+    can_tranciever.can_ttl.rx ~ mux.input_b2
+    button ~ micro.PA4 # for enumeration or something while micro is running
+    micro.PB8_BOOT0 ~ mux.output
+    mux.control ~ micro.PA6
+
+    # Pulldown reistor to default to boot selction - assert high with PA6 to enable CAN
+    select_resistor.1 ~ mux.control.io
+    select_resistor.2 ~ power.gnd
+
+    # Motor controlxx
     phase_a_control ~ micro.PA0
     phase_b_control ~ micro.PA1
     phase_c_control ~ micro.PA2
@@ -47,4 +59,37 @@ module Micro:
 
     # Internal connections
     power ~ micro.power
-    # power ~ can_tranciever.power
+    power ~ can_tranciever.power
+    power ~ mux.power
+
+
+component SN74LVC1G3157DBVR:
+    """
+    Analog multiplexer with two inputs and one output.
+    control L = input_b1 enabled
+    control H = input_b2 enabled
+    """
+    footprint = "SOT-23-6_L2.9-W1.6-P0.95-LS2.8-BR"
+    lcsc_id = "C10426"
+    description = "15Ω 1 SPDT(SPDT) SOT-23-6 Analog Switches / Multiplexers ROHS"
+    mpn = "C10426"
+
+    power = new Power
+    power.vcc ~ pin 5
+    power.gnd ~ pin 2
+
+    input_b1 = new Pair
+    input.io ~ pin 1
+    input.gnd ~ power.gnd
+
+    input_b2 = new Pair
+    output.io ~ pin 3
+    output.gnd ~ power.gnd
+
+    output = new Pair
+    output.io ~ pin 4
+    output.gnd ~ power.gnd
+
+    control = new Pair
+    control.io ~ pin 6
+    control.gnd ~ power.gnd


### PR DESCRIPTION
![Screenshot 2024-03-12 at 1 44 44 PM](https://github.com/atopile/spin-servo-drive/assets/8122613/75dbdf82-0785-48f4-9717-d31c7f9f6d05)

Using this MUX from TI: https://www.ti.com/lit/ds/symlink/sn74lvc1g3157.pdf?ts=1710189618915&ref_url=https%253A%252F%252Fwww.google.com%252F
