### PR TITLE
connect missing adc ref to 3v3

### DIFF
--- a/elec/src/stm32g4/STM32G4.ato
+++ b/elec/src/stm32g4/STM32G4.ato
@@ -44,6 +44,7 @@ module STM32G431CBU6_BASE:
     power ~ ic.power_vdd
     power ~ ic.power_vdda
     power ~ ic.power_vref
+    power ~ ic.power_adc_ref
     # power ~ ic.power_vbat # TODO: Check this
 
     ###### SPI 1 #####

--- a/elec/src/stm32g4/elec/src/STM32G431CBU6.ato
+++ b/elec/src/stm32g4/elec/src/STM32G431CBU6.ato
@@ -11,6 +11,7 @@ component _STM32G431CBU6:
     power_vdda = new Power
     power_vdd = new Power
     power_vref = new Power
+    power_adc_ref = new Power
 
     # signal VREF_ ~ pin 20 # what dis?
     signal gnd
@@ -21,12 +22,14 @@ component _STM32G431CBU6:
     power_vdd.vcc ~ pin 35
     power_vref.vcc ~ pin 23
     power_vbat.vcc ~ pin 1
+    power_adc_ref.vcc ~ pin 20
 
     # Grounds together
     gnd ~ power_vdd.gnd
     gnd ~ power_vdda.gnd
     gnd ~ power_vref.gnd
     gnd ~ power_vbat.gnd
+    gnd ~ power_adc_ref.gnd
     gnd ~ pin 49 # EP
 
     # GPIO - Port A


### PR DESCRIPTION
Vref+ not connected, meant adc was not behaving sensibly.

Connecting to 3v3 rail.